### PR TITLE
[WIP] Improve sound compatibility

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -465,7 +465,7 @@ elseif minetest.get_modpath("stairs") then
 		{"lavastuff_block.png"},
 		S("Lava Stair"),
 		S("Lava Slab"),
-		default.node_sound_glass_defaults(),
+		default and default.node_sound_glass_defaults(),
 		true,
 		S("Inner Lava Stair"),
 		S("Outer Lava Stair")

--- a/init.lua
+++ b/init.lua
@@ -444,7 +444,7 @@ minetest.register_node("lavastuff:block", {
 	description = S("Lava Block"),
 	tiles = {"lavastuff_block.png"},
 	is_ground_content = false,
-	sounds = default and default.node_sound_glass_defaults(),
+	sounds = default and default.node_sound_glass_defaults and default.node_sound_glass_defaults(),
 	groups = {cracky = 2, level = 2},
 	light_source = 6,
 })
@@ -455,7 +455,7 @@ if minetest.get_modpath("moreblocks") then
 		tiles = {"lavastuff_block.png"},
 		groups = {cracky = 2, level = 2},
 		light_source = 6,
-		sounds = default and default.node_sound_glass_defaults(),
+		sounds = default and default.node_sound_glass_defaults and default.node_sound_glass_defaults(),
 	})
 elseif minetest.get_modpath("stairs") then
 	stairs.register_stair_and_slab(
@@ -465,7 +465,7 @@ elseif minetest.get_modpath("stairs") then
 		{"lavastuff_block.png"},
 		S("Lava Stair"),
 		S("Lava Slab"),
-		default and default.node_sound_glass_defaults(),
+		default and default.node_sound_glass_defaults and default.node_sound_glass_defaults(),
 		true,
 		S("Inner Lava Stair"),
 		S("Outer Lava Stair")
@@ -529,7 +529,7 @@ minetest.register_node("lavastuff:lava_in_a_bottle", {
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
 	},
 	groups = {vessel = 1, dig_immediate = 3, attached_node = 1},
-	sounds = default and default.node_sound_glass_defaults(),
+	sounds = default and default.node_sound_glass_defaults and default.node_sound_glass_defaults(),
 })
 
 --

--- a/mod.conf
+++ b/mod.conf
@@ -2,7 +2,7 @@ name = lavastuff
 description = Adds lava tools, armor, and blocks
 title = Lava Stuff
 optional_depends = """
-	mobs, mobs_monster, 3d_armor, toolranks, moreblocks,
+	mobs, mobs_monster, 3d_armor, toolranks, moreblocks, sounds,
 	fire, stairs, vessels, default, bucket,
 	mcl_armor, mcl_fire, mcl_buckets, mcl_nether, mcl_potions, mcl_core, mcl_mobitems, mcl_tools,
 	nc_fire, nc_api_all, nc_lux, nc_optics


### PR DESCRIPTION
Depends on compatibility layer [`sounds`](https://content.minetest.net/packages/AntumDeluge/sounds/). It overrides `default.node_sound_*`, so further modification shouldn’t be necessary, though it’s possible.

The code assumed that the existence of `stairs` implies `default` is also there, but [Stairs Redo](https://content.minetest.net/packages/TenPlus1/stairs/), [Stairs Redux](https://forum.minetest.net/viewtopic.php?t=26360) and “[moreblocks and stairsplus ](https://content.minetest.net/packages/rheo/moreblocks/)” supply a replacement. moreblocks and stairsplus does not depend on default, which led to crash.

In MineClone2 this results in the bottle having destruction sound.
I’m testing in MineClone2 with sounds and “moreblocks and stairsplus” installed. Sounds for breaking the bottle as well as for walking on stairs and moreblocks works.

The sound for normal lava block doesn’t work, which is one reason why this is WIP.

It could further be checked if [`adaptation_lib`](https://content.minetest.net/modnames/adaptation_lib/) can replace or extend the current compatibility.